### PR TITLE
Added performance improvements

### DIFF
--- a/lib/rc4.rb
+++ b/lib/rc4.rb
@@ -2,40 +2,46 @@ class RC4
   def initialize(str)
     begin
       raise SyntaxError, "RC4: Key supplied is blank"  if str.eql?('')
-
+      initialize_state(str)
       @q1, @q2 = 0, 0
-      @key = []
-      str.each_byte { |elem| @key << elem } while @key.size < 256
-      @key.slice!(256..@key.size-1) if @key.size >= 256
-      @s = (0..255).to_a
-      j = 0
-      0.upto(255) do |i|
-        j = (j + @s[i] + @key[i] ) % 256
-        @s[i], @s[j] = @s[j], @s[i]
-      end
     end
   end
 
   def encrypt!(text)
-    process text
+    index = 0
+    while index < text.length
+      @q1 = (@q1 + 1) % 256
+      @q2 = (@q2 + @state[@q1]) % 256
+      @state[@q1], @state[@q2] = @state[@q2], @state[@q1]
+      text.setbyte(index, text.getbyte(index) ^ @state[(@state[@q1] + @state[@q2]) % 256])
+      index += 1
+    end
+    text
   end
 
+  alias_method :decrypt!, :encrypt!
+
   def encrypt(text)
-    process text.dup
+    encrypt!(text.dup)
   end
 
   alias_method :decrypt, :encrypt
 
   private
 
-  def process(text)
-    text.unpack("C*").map { |c| c ^ round }.pack("C*")
+  # The initial state which is then modified by the key-scheduling algorithm
+  INITIAL_STATE = (0..255).to_a
+
+  # Performs the key-scheduling algorithm to initialize the state.
+  def initialize_state(key)
+    i = j = 0
+    @state = INITIAL_STATE.dup
+    key_length = key.length
+    while i < 256
+      j = (j + @state[i] + key.getbyte(i % key_length)) % 256
+      @state[i], @state[j] = @state[j], @state[i]
+      i += 1
+    end
   end
 
-  def round
-    @q1 = (@q1 + 1) % 256
-    @q2 = (@q2 + @s[@q1]) % 256
-    @s[@q1], @s[@q2] = @s[@q2], @s[@q1]
-    @s[(@s[@q1]+@s[@q2]) % 256]
-  end
 end


### PR DESCRIPTION
### Implementation of the proposed changes of issue #12

State initialization
* Extracted it into its own method
* Avoid unnecessary Range to Array conversion
* Using String#getbyte for faster access to bytes of the key string

Algorithm itself
* Not using String#unpack and Array#pack for accessing data bytes
  but using faster String#getbyte and String#setbyte
* Avoids invocation of a block and a method for each byte by
  inlining the code

Simple benchmark:

~~~ ruby
require 'benchmark/ips'
require 'rc4old'
require 'rc4'

Benchmark.ips do |results|
  text = (0..5000).map { rand(256).chr}.join
  key = 'mykey'
  results.report('old RC4') { RC4Old.new(key).encrypt(text) }
  results.report('new RC4') { RC4.new(key).encrypt(text) }
  results.compare!
end
~~~

And its results:

~~~
Calculating -------------------------------------
             old RC4        36 i/100ms
             new RC4        42 i/100ms
-------------------------------------------------
             old RC4      362.8 (±0.8%) i/s -       1836 in   5.060957s
             new RC4      423.6 (±0.5%) i/s -       2142 in   5.056711s

Comparison:
             new RC4:      423.6 i/s
             old RC4:      362.8 i/s - 1.17x slower
~~~