### PR TITLE
use ArgumentError instead of SyntaxError

### DIFF
--- a/lib/rc4.rb
+++ b/lib/rc4.rb
@@ -1,10 +1,8 @@
 class RC4
   def initialize(str)
-    begin
-      raise ArgumentError, "RC4: Key supplied is blank"  if str.eql?('')
-      initialize_state(str)
-      @q1, @q2 = 0, 0
-    end
+    raise ArgumentError, "RC4: Key supplied is blank"  if str.eql?('')
+    initialize_state(str)
+    @q1, @q2 = 0, 0
   end
 
   def encrypt!(text)

--- a/lib/rc4.rb
+++ b/lib/rc4.rb
@@ -1,7 +1,7 @@
 class RC4
   def initialize(str)
     begin
-      raise SyntaxError, "RC4: Key supplied is blank"  if str.eql?('')
+      raise ArgumentError, "RC4: Key supplied is blank"  if str.eql?('')
       initialize_state(str)
       @q1, @q2 = 0, 0
     end

--- a/spec/rc4_spec.rb
+++ b/spec/rc4_spec.rb
@@ -8,7 +8,7 @@ describe RC4 do
   it "should not crypt with a blank key" do
     expect { 
       RC4.new("")
-    }.to raise_error(SyntaxError, "RC4: Key supplied is blank")
+    }.to raise_error(ArgumentError, "RC4: Key supplied is blank")
  
   end
 


### PR DESCRIPTION
The [documentation for SyntaxError](http://ruby-doc.org/core-2.4.1/SyntaxError.html) says:

> Raised when encountering Ruby code with an invalid syntax

This exception isn't a subclass of StandardError, so a standard rescue block won't catch it. It sounds like this exception is intended to be used by the ruby VM and I suspect users will find it more convenient if a subclass of StandardError is raised.

REF: https://github.com/yob/pdf-reader/pull/249